### PR TITLE
[Feat/#3] 전역 에러 처리 및 공통 응답 구조를 정의한다

### DIFF
--- a/src/main/java/spring/bbusinsa/global/error/ApiControllerAdvice.java
+++ b/src/main/java/spring/bbusinsa/global/error/ApiControllerAdvice.java
@@ -1,0 +1,31 @@
+package spring.bbusinsa.global.error;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import spring.bbusinsa.global.response.ApiResponse;
+
+@RestControllerAdvice
+public class ApiControllerAdvice {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    @ExceptionHandler(BbusinsaException.class)
+    public ResponseEntity<ApiResponse<?>> handleBbusinsaException(BbusinsaException e) {
+        switch (e.getErrorType().getLogLevel()) {
+            case ERROR -> log.error("BbusinsaException : {}", e.getMessage(), e);
+            case WARN -> log.warn("BbusinsaException : {}", e.getMessage(), e);
+            default -> log.info("BbusinsaException : {}", e.getMessage(), e);
+        }
+        return new ResponseEntity<>(ApiResponse.error(e.getErrorType(), e.getData()), e.getErrorType().getStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
+        log.error("Exception : {}", e.getMessage(), e);
+        return new ResponseEntity<>(ApiResponse.error(ErrorType.DEFAULT_ERROR), ErrorType.DEFAULT_ERROR.getStatus());
+    }
+
+}

--- a/src/main/java/spring/bbusinsa/global/error/BbusinsaException.java
+++ b/src/main/java/spring/bbusinsa/global/error/BbusinsaException.java
@@ -1,0 +1,24 @@
+package spring.bbusinsa.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class BbusinsaException extends RuntimeException {
+
+    private final ErrorType errorType;
+
+    private final Object data;
+
+    public BbusinsaException(ErrorType errorType) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+        this.data = null;
+    }
+
+    public BbusinsaException(ErrorType errorType, Object data) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+        this.data = data;
+    }
+
+}

--- a/src/main/java/spring/bbusinsa/global/error/ErrorCode.java
+++ b/src/main/java/spring/bbusinsa/global/error/ErrorCode.java
@@ -1,0 +1,5 @@
+package spring.bbusinsa.global.error;
+
+public enum ErrorCode {
+    E500
+}

--- a/src/main/java/spring/bbusinsa/global/error/ErrorMessage.java
+++ b/src/main/java/spring/bbusinsa/global/error/ErrorMessage.java
@@ -1,0 +1,26 @@
+package spring.bbusinsa.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorMessage {
+
+    private final String code;
+
+    private final String message;
+
+    private final Object data;
+
+    public ErrorMessage(ErrorType errorType) {
+        this.code = errorType.getCode().name();
+        this.message = errorType.getMessage();
+        this.data = null;
+    }
+
+    public ErrorMessage(ErrorType errorType, Object data) {
+        this.code = errorType.getCode().name();
+        this.message = errorType.getMessage();
+        this.data = data;
+    }
+
+}

--- a/src/main/java/spring/bbusinsa/global/error/ErrorType.java
+++ b/src/main/java/spring/bbusinsa/global/error/ErrorType.java
@@ -1,0 +1,23 @@
+package spring.bbusinsa.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.logging.LogLevel;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorType {
+
+    DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "An unexpected error has occurred.", LogLevel.ERROR),
+    ;
+
+    private final HttpStatus status;
+
+    private final ErrorCode code;
+
+    private final String message;
+
+    private final LogLevel logLevel;
+
+}

--- a/src/main/java/spring/bbusinsa/global/response/ApiResponse.java
+++ b/src/main/java/spring/bbusinsa/global/response/ApiResponse.java
@@ -1,0 +1,38 @@
+package spring.bbusinsa.global.response;
+
+import lombok.Getter;
+import spring.bbusinsa.global.error.ErrorMessage;
+import spring.bbusinsa.global.error.ErrorType;
+
+@Getter
+public class ApiResponse<T> {
+
+    private final ResultType result;
+
+    private final T data;
+
+    private final ErrorMessage error;
+
+    private ApiResponse(ResultType result, T data, ErrorMessage error) {
+        this.result = result;
+        this.data = data;
+        this.error = error;
+    }
+
+    public static ApiResponse<?> success() {
+        return new ApiResponse<>(ResultType.SUCCESS, null, null);
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(ResultType.SUCCESS, data, null);
+    }
+
+    public static ApiResponse<?> error(ErrorType error) {
+        return new ApiResponse<>(ResultType.ERROR, null, new ErrorMessage(error));
+    }
+
+    public static ApiResponse<?> error(ErrorType error, Object errorData) {
+        return new ApiResponse<>(ResultType.ERROR, null, new ErrorMessage(error, errorData));
+    }
+
+}

--- a/src/main/java/spring/bbusinsa/global/response/ResultType.java
+++ b/src/main/java/spring/bbusinsa/global/response/ResultType.java
@@ -1,0 +1,7 @@
+package spring.bbusinsa.global.response;
+
+public enum ResultType {
+
+    SUCCESS, ERROR
+
+}


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #3 

## 💡 작업 내용
- @RestControllerAdvice를 사용해 에러를 전역적으로 처리합니다.
- ApiResponse를 생성하여 공통/에러 응답 구조를 정의합니다.

## 📸 스크린샷(선택)

## 🎸 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
