### PR TITLE
[Feat/#8] ElasticSearch를 이용한 상품 검색 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+main/resources/elasticsearch-mappings.json

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
+    // elastic search
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,9 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven {
+        url "https://artifacts.elastic.co/maven"
+    }
 }
 
 dependencies {
@@ -30,6 +33,7 @@ dependencies {
 
     // elastic search
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    implementation 'co.elastic.clients:elasticsearch-java:8.13.4'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/spring/bbusinsa/BbusinsaApplication.java
+++ b/src/main/java/spring/bbusinsa/BbusinsaApplication.java
@@ -2,10 +2,12 @@ package spring.bbusinsa;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableElasticsearchRepositories(basePackages = "spring.bbusinsa.product.infra.elasticSearch.domain")
 public class BbusinsaApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/spring/bbusinsa/global/error/ErrorType.java
+++ b/src/main/java/spring/bbusinsa/global/error/ErrorType.java
@@ -16,7 +16,10 @@ public enum ErrorType {
 
     PRODUCT_CATEGORY_IS_INVALID(HttpStatus.BAD_REQUEST, ErrorCode.E400, "Product Category Is Not Available.", LogLevel.ERROR),
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "Product not found.", LogLevel.ERROR),
+    PRODUCT_SEARCH_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "While Searching Product, server error has occurred.", LogLevel.ERROR),
+
     MARKET_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "Market not found.", LogLevel.ERROR),
+    DUPLICATE_MARKET_NAME(HttpStatus.BAD_REQUEST, ErrorCode.E400, "Duplicate Market Name.", LogLevel.ERROR),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/spring/bbusinsa/product/application/ProductSearchService.java
+++ b/src/main/java/spring/bbusinsa/product/application/ProductSearchService.java
@@ -4,6 +4,7 @@ import spring.bbusinsa.product.domain.dto.response.product.ProductListDto;
 
 public interface ProductSearchService {
 
-    ProductListDto searchProductByName(String name);
+    ProductListDto searchProduct(String name, String category, String market);
+    ProductListDto searchProductByPriceRange(int minPrice, int maxPrice);
 
-}
+    }

--- a/src/main/java/spring/bbusinsa/product/application/ProductSearchService.java
+++ b/src/main/java/spring/bbusinsa/product/application/ProductSearchService.java
@@ -1,0 +1,9 @@
+package spring.bbusinsa.product.application;
+
+import spring.bbusinsa.product.domain.dto.response.product.ProductListDto;
+
+public interface ProductSearchService {
+
+    ProductListDto searchProductByName(String name);
+
+}

--- a/src/main/java/spring/bbusinsa/product/application/ProductServiceImpl.java
+++ b/src/main/java/spring/bbusinsa/product/application/ProductServiceImpl.java
@@ -16,6 +16,8 @@ import spring.bbusinsa.product.domain.entity.Product;
 import spring.bbusinsa.product.domain.enums.ProductCategory;
 import spring.bbusinsa.product.domain.repository.MarketRepository;
 import spring.bbusinsa.product.domain.repository.ProductRepository;
+import spring.bbusinsa.product.infra.elasticSearch.domain.ProductDocument;
+import spring.bbusinsa.product.infra.elasticSearch.domain.ProductSearchRepository;
 
 import java.util.List;
 
@@ -24,15 +26,20 @@ import java.util.List;
 public class ProductServiceImpl implements ProductService {
 
     private final ProductRepository productRepository;
+    private final ProductSearchRepository productSearchRepository;
     private final MarketRepository marketRepository;
 
     @Transactional
     @Override
     public MarketDetailDto postMarket(MarketPostDto marketPostDto) {
+
+        if (isExistingMarket(marketPostDto.name())) {
+            throw new BbusinsaException(ErrorType.DUPLICATE_MARKET_NAME);
+        }
+
         Market market = Market.builder()
                 .name(marketPostDto.name())
                 .build();
-
         marketRepository.save(market);
 
         return MarketDetailDto.of(market);
@@ -55,8 +62,17 @@ public class ProductServiceImpl implements ProductService {
                 .content(productPostDto.content())
                 .market(market)
                 .build();
-
         productRepository.save(product);
+
+        ProductDocument productDocs = ProductDocument.builder()
+                .productId(product.getProductId())
+                .price(product.getPrice())
+                .name(product.getName())
+                .category(product.getCategory().name())
+                .content(product.getContent())
+                .market(market.getName())
+                .build();
+        productSearchRepository.save(productDocs);
 
         return ProductDetailDto.of(product);
     }
@@ -84,6 +100,9 @@ public class ProductServiceImpl implements ProductService {
                 .orElseThrow(() -> new BbusinsaException(ErrorType.MARKET_NOT_FOUND));
     }
 
+    private boolean isExistingMarket(String name) {
+        return marketRepository.findByName(name).isPresent();
+    }
 
     private Product findProductById(Long productId) {
         return productRepository.findById(productId)

--- a/src/main/java/spring/bbusinsa/product/domain/dto/response/market/MarketDetailDto.java
+++ b/src/main/java/spring/bbusinsa/product/domain/dto/response/market/MarketDetailDto.java
@@ -1,15 +1,13 @@
 package spring.bbusinsa.product.domain.dto.response.market;
 
-import lombok.Builder;
 import spring.bbusinsa.product.domain.entity.Market;
 
-@Builder
 public record MarketDetailDto(Long marketId, String name) {
 
     public static MarketDetailDto of(Market market) {
-        return MarketDetailDto.builder()
-                .marketId(market.getMarketId())
-                .name(market.getName())
-                .build();
+        return new MarketDetailDto(
+                market.getMarketId(),
+                market.getName()
+        );
     }
 }

--- a/src/main/java/spring/bbusinsa/product/domain/dto/response/market/MarketListDto.java
+++ b/src/main/java/spring/bbusinsa/product/domain/dto/response/market/MarketListDto.java
@@ -1,20 +1,16 @@
 package spring.bbusinsa.product.domain.dto.response.market;
 
-import lombok.Builder;
 import spring.bbusinsa.product.domain.entity.Market;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-@Builder
 public record MarketListDto(List<MarketDetailDto> marketDetailDtoList) {
 
     public static MarketListDto of(List<Market> markets) {
-        return MarketListDto.builder()
-                .marketDetailDtoList(markets.stream().
+        return new MarketListDto(
+                markets.stream().
                         map(MarketDetailDto::of)
-                        .collect(Collectors.toList()))
-                .build();
+                        .toList()
+        );
     }
-
 }

--- a/src/main/java/spring/bbusinsa/product/domain/dto/response/product/ProductDetailDto.java
+++ b/src/main/java/spring/bbusinsa/product/domain/dto/response/product/ProductDetailDto.java
@@ -23,7 +23,7 @@ public record ProductDetailDto(Long productId,
 
     public static ProductDetailDto of(ProductDocument productDocument) {
         return new ProductDetailDto(
-                productDocument.getProductId(),
+                productDocument.getId(),
                 productDocument.getMarket(),
                 productDocument.getName(),
                 productDocument.getPrice(),

--- a/src/main/java/spring/bbusinsa/product/domain/dto/response/product/ProductDetailDto.java
+++ b/src/main/java/spring/bbusinsa/product/domain/dto/response/product/ProductDetailDto.java
@@ -1,9 +1,8 @@
 package spring.bbusinsa.product.domain.dto.response.product;
 
-import lombok.Builder;
 import spring.bbusinsa.product.domain.entity.Product;
+import spring.bbusinsa.product.infra.elasticSearch.domain.ProductDocument;
 
-@Builder
 public record ProductDetailDto(Long productId,
                                String marketName,
                                String productName,
@@ -12,13 +11,24 @@ public record ProductDetailDto(Long productId,
                                String content) {
 
     public static ProductDetailDto of(Product product) {
-        return ProductDetailDto.builder()
-                .productId(product.getProductId())
-                .marketName(product.getMarket().getName())
-                .productName(product.getName())
-                .price(product.getPrice())
-                .category(product.getCategory().name())
-                .content(product.getContent())
-                .build();
+        return new ProductDetailDto(
+                product.getProductId(),
+                product.getMarket().getName(),
+                product.getName(),
+                product.getPrice(),
+                product.getCategory().name(),
+                product.getContent()
+        );
+    }
+
+    public static ProductDetailDto of(ProductDocument productDocument) {
+        return new ProductDetailDto(
+                productDocument.getProductId(),
+                productDocument.getMarket(),
+                productDocument.getName(),
+                productDocument.getPrice(),
+                productDocument.getCategory(),
+                productDocument.getContent()
+        );
     }
 }

--- a/src/main/java/spring/bbusinsa/product/domain/dto/response/product/ProductDetailDto.java
+++ b/src/main/java/spring/bbusinsa/product/domain/dto/response/product/ProductDetailDto.java
@@ -23,7 +23,7 @@ public record ProductDetailDto(Long productId,
 
     public static ProductDetailDto of(ProductDocument productDocument) {
         return new ProductDetailDto(
-                productDocument.getId(),
+                productDocument.getProductId(),
                 productDocument.getMarket(),
                 productDocument.getName(),
                 productDocument.getPrice(),

--- a/src/main/java/spring/bbusinsa/product/domain/dto/response/product/ProductListDto.java
+++ b/src/main/java/spring/bbusinsa/product/domain/dto/response/product/ProductListDto.java
@@ -1,19 +1,23 @@
 package spring.bbusinsa.product.domain.dto.response.product;
 
-import lombok.Builder;
 import spring.bbusinsa.product.domain.entity.Product;
+import spring.bbusinsa.product.infra.elasticSearch.domain.ProductDocument;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-@Builder
 public record ProductListDto(List<ProductDetailDto> productDetailDtoList) {
 
-    public static ProductListDto of(List<Product> productList) {
-        return ProductListDto.builder()
-                .productDetailDtoList(productList.stream()
-                        .map(ProductDetailDto::of)
-                        .collect(Collectors.toList()))
-                .build();
+    public static <T>ProductListDto of(List<T> productList) {
+        return new ProductListDto(
+            productList.stream()
+                    .map(product -> {
+                        if (product instanceof Product p) {
+                            return ProductDetailDto.of(p);
+                        } else if (product instanceof ProductDocument d) {
+                            return ProductDetailDto.of(d);
+                        }
+                        throw new IllegalArgumentException("Unsupported type: " + product.getClass());
+                    }).toList()
+        );
     }
 }

--- a/src/main/java/spring/bbusinsa/product/infra/elasticSearch/application/ProductSearchServiceImpl.java
+++ b/src/main/java/spring/bbusinsa/product/infra/elasticSearch/application/ProductSearchServiceImpl.java
@@ -1,0 +1,39 @@
+package spring.bbusinsa.product.infra.elasticSearch.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import spring.bbusinsa.product.application.ProductSearchService;
+import spring.bbusinsa.product.domain.dto.response.product.ProductListDto;
+import spring.bbusinsa.product.infra.elasticSearch.domain.ProductDocument;
+import spring.bbusinsa.product.infra.elasticSearch.domain.ProductSearchRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProductSearchServiceImpl implements ProductSearchService {
+
+    private final ProductSearchRepository productSearchRepository;
+
+
+    @Override
+    public ProductListDto searchProductByName(String name) {
+        List<ProductDocument> productDocuments = productSearchRepository.findByName(name);
+        return ProductListDto.of(productDocuments);
+    }
+
+    public ProductListDto searchProductByCategory(String category) {
+        List<ProductDocument> productDocuments = productSearchRepository.findByCategory(category);
+        return ProductListDto.of(productDocuments);
+    }
+
+    public ProductListDto searchProductByMarket(String market) {
+        List<ProductDocument> productDocuments = productSearchRepository.findByMarket(market);
+        return ProductListDto.of(productDocuments);
+    }
+
+    public ProductListDto searchProductByPriceRange(int minPrice, int maxPrice) {
+        List<ProductDocument> productDocuments = productSearchRepository.findByPriceIsBetween(minPrice, maxPrice);
+        return ProductListDto.of(productDocuments);
+    }
+}

--- a/src/main/java/spring/bbusinsa/product/infra/elasticSearch/application/ProductSearchServiceImpl.java
+++ b/src/main/java/spring/bbusinsa/product/infra/elasticSearch/application/ProductSearchServiceImpl.java
@@ -1,37 +1,89 @@
 package spring.bbusinsa.product.infra.elasticSearch.application;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
 import lombok.RequiredArgsConstructor;
+
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import spring.bbusinsa.global.error.BbusinsaException;
+import spring.bbusinsa.global.error.ErrorType;
 import spring.bbusinsa.product.application.ProductSearchService;
 import spring.bbusinsa.product.domain.dto.response.product.ProductListDto;
+import spring.bbusinsa.product.domain.enums.ProductCategory;
+import spring.bbusinsa.product.domain.repository.MarketRepository;
 import spring.bbusinsa.product.infra.elasticSearch.domain.ProductDocument;
 import spring.bbusinsa.product.infra.elasticSearch.domain.ProductSearchRepository;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ProductSearchServiceImpl implements ProductSearchService {
 
     private final ProductSearchRepository productSearchRepository;
-
+    private final MarketRepository marketRepository;
+    private final ElasticsearchClient elasticsearchClient;
 
     @Override
-    public ProductListDto searchProductByName(String name) {
-        List<ProductDocument> productDocuments = productSearchRepository.findByName(name);
-        return ProductListDto.of(productDocuments);
+    public ProductListDto searchProduct(String name, String category, String market) {
+        List<Query> shouldQueries = Stream.of(
+                buildMatchQuery("name", name),
+                buildTermQuery("category.keyword", category),
+                buildTermQuery("market.keyword", market)
+        ).flatMap(Optional::stream).toList();
+
+        BoolQuery boolQuery = shouldQueries.isEmpty()
+                ? BoolQuery.of(b -> b.must(Query.of(q -> q.matchAll(m -> m))))
+                : BoolQuery.of(b -> b.must(shouldQueries));
+
+        SearchRequest searchRequest = SearchRequest.of(s -> s
+                .index("product")
+                .query(Query.of(q -> q.bool(boolQuery)))
+        );
+
+        try {
+            SearchResponse<ProductDocument> response = elasticsearchClient.search(searchRequest, ProductDocument.class);
+            List<ProductDocument> productDocuments =
+                    response.hits().hits().stream()
+                            .map(hit -> hit.source())
+                            .collect(Collectors.toList());
+
+            return ProductListDto.of(productDocuments);
+
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new BbusinsaException(ErrorType.PRODUCT_SEARCH_INTERNAL_SERVER_ERROR);
+        }
     }
 
-    public ProductListDto searchProductByCategory(String category) {
-        List<ProductDocument> productDocuments = productSearchRepository.findByCategory(category);
-        return ProductListDto.of(productDocuments);
+    private Optional<Query> buildMatchQuery(String field, String value) {
+        return (value == null || value.isEmpty()) ? Optional.empty()
+                : Optional.of(Query.of(q -> q.match(m -> m.field(field).query(value))));
     }
 
-    public ProductListDto searchProductByMarket(String market) {
-        List<ProductDocument> productDocuments = productSearchRepository.findByMarket(market);
-        return ProductListDto.of(productDocuments);
+    private Optional<Query> buildTermQuery(String field, String value) {
+        if (value == null || value.isEmpty()) return Optional.empty();
+
+        if ("market.keyword".equals(field) && marketRepository.findByName(value).isEmpty()) {
+            throw new BbusinsaException(ErrorType.MARKET_NOT_FOUND);
+        } else if ("category.keyword".equals(field)) {
+            ProductCategory.valueOf(value);
+        }
+
+        return Optional.of(Query.of(q -> q.term(t -> t.field(field).value(FieldValue.of(value)))));
     }
 
+    @Override
     public ProductListDto searchProductByPriceRange(int minPrice, int maxPrice) {
         List<ProductDocument> productDocuments = productSearchRepository.findByPriceIsBetween(minPrice, maxPrice);
         return ProductListDto.of(productDocuments);

--- a/src/main/java/spring/bbusinsa/product/infra/elasticSearch/config/ElasticSearchConfig.java
+++ b/src/main/java/spring/bbusinsa/product/infra/elasticSearch/config/ElasticSearchConfig.java
@@ -1,0 +1,18 @@
+package spring.bbusinsa.product.infra.elasticSearch.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Configuration
+@EnableElasticsearchRepositories(basePackages = "org.springframework.data.elasticsearch.repository")
+public class ElasticSearchConfig extends ElasticsearchConfiguration {
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+                .connectedTo("localhost:9200")
+                .build();
+    }
+}

--- a/src/main/java/spring/bbusinsa/product/infra/elasticSearch/config/ElasticSearchConfig.java
+++ b/src/main/java/spring/bbusinsa/product/infra/elasticSearch/config/ElasticSearchConfig.java
@@ -10,11 +10,11 @@ import org.springframework.data.elasticsearch.repository.config.EnableElasticsea
 @EnableElasticsearchRepositories(basePackages = "org.springframework.data.elasticsearch.repository")
 public class ElasticSearchConfig extends ElasticsearchConfiguration {
 
-    @Value("${spring.elasticsearch.username}")
-    private String username;
+//    @Value("${spring.elasticsearch.username}")
+//    private String username;
 
-    @Value("${spring.elasticsearch.password}")
-    private String password;
+//    @Value("${spring.elasticsearch.password}")
+//    private String password;
 
     @Value("${spring.elasticsearch.uris}")
     private String[] esHost;
@@ -23,7 +23,7 @@ public class ElasticSearchConfig extends ElasticsearchConfiguration {
     public ClientConfiguration clientConfiguration() {
         return ClientConfiguration.builder()
                 .connectedTo(esHost)
-                .withBasicAuth(username, password)
+//                .withBasicAuth(username, password)
                 .build();
     }
 }

--- a/src/main/java/spring/bbusinsa/product/infra/elasticSearch/config/ElasticSearchConfig.java
+++ b/src/main/java/spring/bbusinsa/product/infra/elasticSearch/config/ElasticSearchConfig.java
@@ -1,5 +1,6 @@
 package spring.bbusinsa.product.infra.elasticSearch.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
@@ -9,10 +10,20 @@ import org.springframework.data.elasticsearch.repository.config.EnableElasticsea
 @EnableElasticsearchRepositories(basePackages = "org.springframework.data.elasticsearch.repository")
 public class ElasticSearchConfig extends ElasticsearchConfiguration {
 
+    @Value("${spring.elasticsearch.username}")
+    private String username;
+
+    @Value("${spring.elasticsearch.password}")
+    private String password;
+
+    @Value("${spring.elasticsearch.uris}")
+    private String[] esHost;
+
     @Override
     public ClientConfiguration clientConfiguration() {
         return ClientConfiguration.builder()
-                .connectedTo("localhost:9200")
+                .connectedTo(esHost)
+                .withBasicAuth(username, password)
                 .build();
     }
 }

--- a/src/main/java/spring/bbusinsa/product/infra/elasticSearch/config/ElasticSearchConfig.java
+++ b/src/main/java/spring/bbusinsa/product/infra/elasticSearch/config/ElasticSearchConfig.java
@@ -1,14 +1,18 @@
 package spring.bbusinsa.product.infra.elasticSearch.config;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.elasticsearch.client.ClientConfiguration;
-import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 
 @Configuration
 @EnableElasticsearchRepositories(basePackages = "org.springframework.data.elasticsearch.repository")
-public class ElasticSearchConfig extends ElasticsearchConfiguration {
+public class ElasticSearchConfig{
 
 //    @Value("${spring.elasticsearch.username}")
 //    private String username;
@@ -17,13 +21,20 @@ public class ElasticSearchConfig extends ElasticsearchConfiguration {
 //    private String password;
 
     @Value("${spring.elasticsearch.uris}")
-    private String[] esHost;
+    private String esHost;
 
-    @Override
-    public ClientConfiguration clientConfiguration() {
-        return ClientConfiguration.builder()
-                .connectedTo(esHost)
-//                .withBasicAuth(username, password)
-                .build();
+    @Bean
+    public RestClient restClient() {
+        return RestClient.builder(HttpHost.create(esHost)).build();
+    }
+
+    @Bean
+    public RestClientTransport restClientTransport(RestClient restClient) {
+        return new RestClientTransport(restClient, new JacksonJsonpMapper());
+    }
+
+    @Bean
+    public ElasticsearchClient elasticsearchClient(RestClientTransport transport) {
+        return new ElasticsearchClient(transport);
     }
 }

--- a/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductDocument.java
+++ b/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductDocument.java
@@ -31,4 +31,7 @@ public class ProductDocument {
     @Field(type = FieldType.Text)
     private String content;
 
+    @Field(type = FieldType.Keyword)
+    private String market;
+
 }

--- a/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductDocument.java
+++ b/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductDocument.java
@@ -16,7 +16,10 @@ import org.springframework.data.elasticsearch.annotations.*;
 public class ProductDocument {
 
     @Id
-    private Long id;
+    private String id;
+
+    @Field(type = FieldType.Long)
+    private Long productId;
 
     @Field(type = FieldType.Keyword) // text multi field
     private String name;

--- a/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductDocument.java
+++ b/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductDocument.java
@@ -1,0 +1,34 @@
+package spring.bbusinsa.product.infra.elasticSearch.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.*;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(indexName = "product")
+@Mapping(mappingPath = "/elasticsearch-mappings.json")
+public class ProductDocument {
+
+    @Id
+    @Field(name = "productId", type = FieldType.Long)
+    private Long productId;
+
+    @Field(type = FieldType.Keyword) // text multi field
+    private String name;
+
+    @Field(type = FieldType.Integer)
+    private int price;
+
+    @Field(type = FieldType.Keyword)
+    private String category;
+
+    @Field(type = FieldType.Text)
+    private String content;
+
+}

--- a/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductDocument.java
+++ b/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductDocument.java
@@ -16,8 +16,7 @@ import org.springframework.data.elasticsearch.annotations.*;
 public class ProductDocument {
 
     @Id
-    @Field(name = "productId", type = FieldType.Long)
-    private Long productId;
+    private Long id;
 
     @Field(type = FieldType.Keyword) // text multi field
     private String name;

--- a/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductDocument.java
+++ b/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductDocument.java
@@ -1,5 +1,6 @@
 package spring.bbusinsa.product.infra.elasticSearch.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -7,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.elasticsearch.annotations.*;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Builder
 @Getter
 @AllArgsConstructor

--- a/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductSearchRepository.java
+++ b/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductSearchRepository.java
@@ -5,5 +5,10 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 import java.util.List;
 
 public interface ProductSearchRepository extends ElasticsearchRepository<ProductDocument, Long> {
+
     List<ProductDocument> findByName(String name);
+    List<ProductDocument> findByCategory(String category);
+    List<ProductDocument> findByMarket(String market);
+    List<ProductDocument> findByPriceIsBetween(int min, int max);
+
 }

--- a/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductSearchRepository.java
+++ b/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductSearchRepository.java
@@ -1,0 +1,9 @@
+package spring.bbusinsa.product.infra.elasticSearch.domain;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import java.util.List;
+
+public interface ProductSearchRepository extends ElasticsearchRepository<ProductDocument, Long> {
+    List<ProductDocument> findByName(String name);
+}

--- a/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductSearchRepository.java
+++ b/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductSearchRepository.java
@@ -1,9 +1,11 @@
 package spring.bbusinsa.product.infra.elasticSearch.domain;
 
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface ProductSearchRepository extends ElasticsearchRepository<ProductDocument, Long> {
 
     List<ProductDocument> findByName(String name);

--- a/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductSearchRepository.java
+++ b/src/main/java/spring/bbusinsa/product/infra/elasticSearch/domain/ProductSearchRepository.java
@@ -6,11 +6,8 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ProductSearchRepository extends ElasticsearchRepository<ProductDocument, Long> {
+public interface ProductSearchRepository extends ElasticsearchRepository<ProductDocument, String> {
 
-    List<ProductDocument> findByName(String name);
-    List<ProductDocument> findByCategory(String category);
-    List<ProductDocument> findByMarket(String market);
     List<ProductDocument> findByPriceIsBetween(int min, int max);
 
 }

--- a/src/main/java/spring/bbusinsa/product/presentation/ProductController.java
+++ b/src/main/java/spring/bbusinsa/product/presentation/ProductController.java
@@ -3,6 +3,7 @@ package spring.bbusinsa.product.presentation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import spring.bbusinsa.global.response.ApiResponse;
+import spring.bbusinsa.product.application.ProductSearchService;
 import spring.bbusinsa.product.application.ProductService;
 import spring.bbusinsa.product.domain.dto.request.MarketPostDto;
 import spring.bbusinsa.product.domain.dto.request.ProductPostDto;
@@ -17,6 +18,7 @@ import spring.bbusinsa.product.domain.dto.response.product.ProductListDto;
 public class ProductController {
 
     private final ProductService productService;
+    private final ProductSearchService productSearchService;
 
     @PostMapping("/markets")
     public ApiResponse<MarketDetailDto> postMarket(
@@ -49,6 +51,11 @@ public class ProductController {
             @PathVariable(name = "marketId") Long marketId
     ) {
         return ApiResponse.success(productService.getProductListOfMarket(marketId));
+    }
+
+    @GetMapping("/products/search")
+    public ApiResponse<ProductListDto> searchProducts() {
+        return ApiResponse.success(productSearchService.searchProductByName(""));
     }
 
 }

--- a/src/main/java/spring/bbusinsa/product/presentation/ProductController.java
+++ b/src/main/java/spring/bbusinsa/product/presentation/ProductController.java
@@ -55,9 +55,11 @@ public class ProductController {
 
     @GetMapping("/search")
     public ApiResponse<ProductListDto> searchProducts(
-            @RequestParam(name = "query") String query
+            @RequestParam(name = "name", required = false) String name,
+            @RequestParam(name = "category", required = false) String category,
+            @RequestParam(name = "market", required = false) String market
     ) {
-        return ApiResponse.success(productSearchService.searchProductByName(query));
+        return ApiResponse.success(productSearchService.searchProduct(name, category, market));
     }
 
 }

--- a/src/main/java/spring/bbusinsa/product/presentation/ProductController.java
+++ b/src/main/java/spring/bbusinsa/product/presentation/ProductController.java
@@ -54,8 +54,10 @@ public class ProductController {
     }
 
     @GetMapping("/products/search")
-    public ApiResponse<ProductListDto> searchProducts() {
-        return ApiResponse.success(productSearchService.searchProductByName(""));
+    public ApiResponse<ProductListDto> searchProducts(
+            @RequestParam(name = "query") String query
+    ) {
+        return ApiResponse.success(productSearchService.searchProductByName(query));
     }
 
 }

--- a/src/main/java/spring/bbusinsa/product/presentation/ProductController.java
+++ b/src/main/java/spring/bbusinsa/product/presentation/ProductController.java
@@ -53,7 +53,7 @@ public class ProductController {
         return ApiResponse.success(productService.getProductListOfMarket(marketId));
     }
 
-    @GetMapping("/products/search")
+    @GetMapping("/search")
     public ApiResponse<ProductListDto> searchProducts(
             @RequestParam(name = "query") String query
     ) {

--- a/src/main/java/spring/bbusinsa/user/domain/dto/response/MemberDetailDto.java
+++ b/src/main/java/spring/bbusinsa/user/domain/dto/response/MemberDetailDto.java
@@ -1,19 +1,21 @@
 package spring.bbusinsa.user.domain.dto.response;
 
-import lombok.Builder;
 import spring.bbusinsa.user.domain.entity.Member;
 import spring.bbusinsa.user.domain.enums.Gender;
 
-@Builder
-public record MemberDetailDto(Long memberId, String name, String email, int age, Gender gender) {
+public record MemberDetailDto(Long memberId,
+                              String name,
+                              String email,
+                              int age,
+                              Gender gender) {
 
     public static MemberDetailDto of(Member member) {
-        return MemberDetailDto.builder()
-                .memberId(member.getMemberId())
-                .name(member.getName())
-                .email(member.getEmail())
-                .age(member.getAge())
-                .gender(member.getGender())
-                .build();
+        return new MemberDetailDto(
+                member.getMemberId(),
+                member.getName(),
+                member.getEmail(),
+                member.getAge(),
+                member.getGender()
+        );
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
   elasticsearch:
 #    username: elastic
 #    password:
-    uris: localhost
+    uris: localhost:9200
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,29 @@
 spring:
   application:
     name: bbusinsa
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_NAME}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  sql:
+    init:
+      platform: mysql
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: update
+    generate-ddl: true
+    show-sql: true
+    properties:
+      format_sql: true
+
+  elasticsearch:
+#    username: elastic
+#    password:
+    uris: localhost
+
+logging:
+  level:
+    org.elasticsearch.client: DEBUG
+

--- a/src/main/resources/elasticsearch-mappings.json
+++ b/src/main/resources/elasticsearch-mappings.json
@@ -1,5 +1,8 @@
 {
   "properties": {
+    "productId": {
+      "type": "long"
+    },
     "name": {
       "type": "keyword",
       "fields": {

--- a/src/main/resources/elasticsearch-mappings.json
+++ b/src/main/resources/elasticsearch-mappings.json
@@ -1,0 +1,23 @@
+{
+  "mappings": {
+    "properties": {
+      "name": {
+        "type": "keyword",
+        "fields": {
+          "text": {
+            "type": "text"
+          }
+        }
+      },
+      "price": {
+        "type": "integer"
+      },
+      "category": {
+        "type": "keyword"
+      },
+      "content": {
+        "type": "text"
+      }
+    }
+  }
+}

--- a/src/main/resources/elasticsearch-mappings.json
+++ b/src/main/resources/elasticsearch-mappings.json
@@ -1,26 +1,24 @@
 {
-  "mappings": {
-    "properties": {
-      "name": {
-        "type": "keyword",
-        "fields": {
-          "text": {
-            "type": "text"
-          }
+  "properties": {
+    "name": {
+      "type": "keyword",
+      "fields": {
+        "text": {
+          "type": "text"
         }
-      },
-      "price": {
-        "type": "integer"
-      },
-      "category": {
-        "type": "keyword"
-      },
-      "content": {
-        "type": "text"
-      },
-      "market": {
-        "type": "keyword"
       }
+    },
+    "price": {
+      "type": "integer"
+    },
+    "category": {
+      "type": "keyword"
+    },
+    "content": {
+      "type": "text"
+    },
+    "market": {
+      "type": "keyword"
     }
   }
 }

--- a/src/main/resources/elasticsearch-mappings.json
+++ b/src/main/resources/elasticsearch-mappings.json
@@ -17,6 +17,9 @@
       },
       "content": {
         "type": "text"
+      },
+      "market": {
+        "type": "keyword"
       }
     }
   }


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #8 

## 💡 작업 내용
- elasticsearch를 기반으로 `상품 이름`, `카테고리`, `마켓 이름` 조건에 대해 동적으로 상품을 검색하는 기능 구현했습니다.
  - 세 조건 모두 `Null`일 경우 전체 상품을 조회합니다.
  - 기존 `ProductDetailDto`에 검색 결과를 맵핑하여 반환합니다.
  - 검색 조건 
    - **상품이름** : text 기반 검색
    - **카테고리** : `ProductCategory` ENUM(`TOP, OUTER, BOTTOM, ETC`)에 부합하는 keyword 기반 검색
    - **마켓이름** : 생성된 `Market` 이름에 부합하는 keyword 기반 검색 (이름 존재 여부 확인)
- `Product` 등록 시 entity를 `ProductDocument`로 매핑해 `productSearchRepository`에도 함께 저장합니다. 
  - `ProductDocument` : elasticsearch에서 사용되는 document입니다. 


## 📸 스크린샷(선택)
<img width="750" alt="스크린샷 2025-02-26 오전 4 27 49" src="https://github.com/user-attachments/assets/a49032e7-4693-4d60-9c6d-cb438b5a3f96" />


## 🎸 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
  - **상품 변경**, **삭제** 시 `ProductDocument`에게 요구되는 작업은 추후 반영 예정입니다.
- elasticsearch security
  - 현재 배포가 되지 않은 상태라, `local elasticsearch` 구동 중에는 security를 모두 해제한 상태로 작업했습니다. 
  - 배포 이후 `yml` 및 `elasticSearchConfig` 수정하겠습니다.
