### PR TITLE
[Feat/#14] Redisson 분산락을 이용하여 동시성 이슈를 해결한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.24.3'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -34,6 +36,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  redis:
+    container_name: bbusinsa_redis
+    image: redis:7.4.2
+    ports:
+      - '6379:6379'
+    volumes:
+      - redis-data:/data
+      - ./docker/redis/conf/redis.conf:/usr/local/etc/redis/redis.conf
+
+volumes:
+  redis-data:

--- a/src/main/java/spring/bbusinsa/coupon/application/CouponService.java
+++ b/src/main/java/spring/bbusinsa/coupon/application/CouponService.java
@@ -1,4 +1,8 @@
 package spring.bbusinsa.coupon.application;
 
 public interface CouponService {
+
+    void reduceCouponStock(Long couponId);
+
+    void reduceCouponStockWithLock(Long couponId);
 }

--- a/src/main/java/spring/bbusinsa/coupon/application/CouponServiceImpl.java
+++ b/src/main/java/spring/bbusinsa/coupon/application/CouponServiceImpl.java
@@ -1,13 +1,74 @@
 package spring.bbusinsa.coupon.application;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
-import spring.bbusinsa.coupon.domain.repository.CouponRepository;
+import org.springframework.transaction.annotation.Transactional;
+import spring.bbusinsa.coupon.domain.entitty.TestCoupon;
+import spring.bbusinsa.coupon.domain.repository.TestCouponRepository;
+import spring.bbusinsa.global.error.BbusinsaException;
+import spring.bbusinsa.global.error.ErrorType;
+
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
+@Log4j2
 public class CouponServiceImpl implements CouponService {
 
-    private final CouponRepository couponRepository;
+    private final TestCouponRepository testCouponRepository;
+    private final CouponTransactionService couponTransactionService;
 
+    private final RedissonClient redissonClient;
+
+    @Override
+    @Transactional
+    public void reduceCouponStock(Long couponId) {
+        log.info("🚀 [START] 쿠폰 차감 요청: couponId={}, thread={}", couponId, Thread.currentThread().getName());
+
+        TestCoupon coupon = testCouponRepository.findById(couponId)
+                .orElseThrow(() -> {
+                    log.error("❌ [ERROR] 쿠폰 조회 실패: couponId={}", couponId);
+                    return new BbusinsaException(ErrorType.COUPON_NOT_FOUND);
+                });
+
+        log.info("✅ [SUCCESS] 쿠폰 조회 완료: couponId={}, 현재 재고={}", couponId, coupon.getAvailableStock());
+
+        coupon.decrease();
+
+        log.info("📉 [UPDATE] 쿠폰 차감 완료: couponId={}, 차감 후 재고={}", couponId, coupon.getAvailableStock());
+
+        log.info("🎯 [END] 트랜잭션 종료: couponId={}", couponId);
+    }
+
+    @Override
+    public void reduceCouponStockWithLock(Long couponId) {
+        RLock lock = redissonClient.getLock("coupon:" + couponId);
+        boolean isLocked = false;
+
+        try {
+            log.info("🔐 [쿠폰 차감] 쿠폰 ID: {} - 락 획득 시도 중...", couponId);
+            isLocked = lock.tryLock(5L, 10L, TimeUnit.SECONDS);
+
+            if (!isLocked) {
+                log.warn("🚨 [쿠폰 차감] 쿠폰 ID: {} - 락 획득 실패: 다른 스레드가 이미 사용 중", couponId);
+                return;
+            }
+
+            log.info("✅ [쿠폰 차감] 쿠폰 ID: {} - 락 획득 성공! 처리 시작", couponId);
+            couponTransactionService.reduceCouponStockWithTransaction(couponId);
+            log.info("🎉 [쿠폰 차감] 쿠폰 ID: {} - 차감 완료!", couponId);
+
+        } catch (InterruptedException e) {
+            log.error("❌ [쿠폰 차감] 쿠폰 ID: {} - 락 획득 중 인터럽트 발생!", couponId, e);
+            throw new BbusinsaException(ErrorType.LOCK_ACQUISITION_FAILED);
+        } finally {
+            if (isLocked && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                log.info("🔓 [쿠폰 차감] 쿠폰 ID: {} - 락 해제 완료", couponId);
+            }
+        }
+    }
 }

--- a/src/main/java/spring/bbusinsa/coupon/application/CouponTransactionService.java
+++ b/src/main/java/spring/bbusinsa/coupon/application/CouponTransactionService.java
@@ -1,0 +1,25 @@
+package spring.bbusinsa.coupon.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import spring.bbusinsa.coupon.domain.entitty.TestCoupon;
+import spring.bbusinsa.coupon.domain.repository.TestCouponRepository;
+import spring.bbusinsa.global.error.BbusinsaException;
+import spring.bbusinsa.global.error.ErrorType;
+
+@Service
+@RequiredArgsConstructor
+public class CouponTransactionService {
+
+    private final TestCouponRepository testCouponRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void reduceCouponStockWithTransaction(Long couponId) {
+        TestCoupon coupon = testCouponRepository.findById(couponId)
+                .orElseThrow(() -> new BbusinsaException(ErrorType.COUPON_NOT_FOUND));
+
+        coupon.decrease();
+    }
+}

--- a/src/main/java/spring/bbusinsa/coupon/domain/entitty/TestCoupon.java
+++ b/src/main/java/spring/bbusinsa/coupon/domain/entitty/TestCoupon.java
@@ -1,0 +1,41 @@
+package spring.bbusinsa.coupon.domain.entitty;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import spring.bbusinsa.global.error.BbusinsaException;
+import spring.bbusinsa.global.error.ErrorType;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TestCoupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private Long availableStock;
+
+    public TestCoupon(String name, Long availableStock) {
+        this.name = name;
+        this.availableStock = availableStock;
+    }
+
+    public void decrease() {
+        validateStockCount();
+        this.availableStock -= 1;
+    }
+
+    private void validateStockCount() {
+        if (availableStock < 1) {
+            throw new BbusinsaException(ErrorType.COUPON_NOT_EXIST);
+        }
+    }
+}

--- a/src/main/java/spring/bbusinsa/coupon/domain/repository/TestCouponRepository.java
+++ b/src/main/java/spring/bbusinsa/coupon/domain/repository/TestCouponRepository.java
@@ -1,0 +1,9 @@
+package spring.bbusinsa.coupon.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import spring.bbusinsa.coupon.domain.entitty.TestCoupon;
+
+@Repository
+public interface TestCouponRepository extends JpaRepository<TestCoupon, Long> {
+}

--- a/src/main/java/spring/bbusinsa/coupon/presentation/CouponController.java
+++ b/src/main/java/spring/bbusinsa/coupon/presentation/CouponController.java
@@ -1,9 +1,12 @@
 package spring.bbusinsa.coupon.presentation;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import spring.bbusinsa.coupon.application.CouponService;
+import spring.bbusinsa.global.response.ApiResponse;
 
 @RestController
 @RequestMapping("/coupons")
@@ -12,4 +15,15 @@ public class CouponController {
 
     private final CouponService couponService;
 
+    @GetMapping("/claim/{couponId}")
+    public ApiResponse<?> claim(@PathVariable Long couponId) {
+        couponService.reduceCouponStock(couponId);
+        return ApiResponse.success();
+    }
+
+    @GetMapping("/claim/lock/{couponId}")
+    public ApiResponse<?> claimByLock(@PathVariable Long couponId) {
+        couponService.reduceCouponStockWithLock(couponId);
+        return ApiResponse.success();
+    }
 }

--- a/src/main/java/spring/bbusinsa/global/config/RedisConfiguration.java
+++ b/src/main/java/spring/bbusinsa/global/config/RedisConfiguration.java
@@ -1,0 +1,37 @@
+package spring.bbusinsa.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfiguration {
+
+    @Value("${spring.data.redis.port}")
+    public int port;
+
+    @Value("${spring.data.redis.host}")
+    public String host;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setConnectionFactory(connectionFactory);
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/spring/bbusinsa/global/config/SwaggerConfig.java
+++ b/src/main/java/spring/bbusinsa/global/config/SwaggerConfig.java
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Configuration;
                 description = "Backend Bbusigi",
                 version = "v1"),
         servers = {
-                @Server(url = "http://localhost",
+                @Server(url = "http://localhost:8080",
                         description = "서버 URL"),
         }
 )

--- a/src/main/java/spring/bbusinsa/global/error/ErrorType.java
+++ b/src/main/java/spring/bbusinsa/global/error/ErrorType.java
@@ -11,6 +11,10 @@ public enum ErrorType {
 
     DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "An unexpected error has occurred.", LogLevel.ERROR),
 
+    COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "Coupon not found.", LogLevel.ERROR),
+    COUPON_NOT_EXIST(HttpStatus.NOT_FOUND, ErrorCode.E500, "Coupon not exist.", LogLevel.ERROR),
+    LOCK_ACQUISITION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "Lock acquisition failed.", LogLevel.ERROR),
+
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "Member not found.", LogLevel.ERROR),
     MEMBER_GENDER_IS_INVALID(HttpStatus.BAD_REQUEST, ErrorCode.E400, "Member Gender Is Not Available.", LogLevel.ERROR),
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,18 @@
 spring:
-  application:
-    name: bbusinsa
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/bbusinsa
+    username: root
+    password:
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+    hibernate:
+      ddl-auto: update
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      connect-timeout: 3000

--- a/src/test/java/spring/bbusinsa/coupon/application/CouponServiceImplTest.java
+++ b/src/test/java/spring/bbusinsa/coupon/application/CouponServiceImplTest.java
@@ -1,0 +1,85 @@
+package spring.bbusinsa.coupon.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import spring.bbusinsa.coupon.domain.entitty.TestCoupon;
+import spring.bbusinsa.coupon.domain.repository.TestCouponRepository;
+import spring.bbusinsa.global.error.BbusinsaException;
+import spring.bbusinsa.global.error.ErrorType;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class CouponServiceImplTest {
+
+    @Autowired
+    TestCouponRepository testCouponRepository;
+
+    @Autowired
+    CouponService couponService;
+
+    TestCoupon coupon;
+
+    @BeforeEach
+    void setUp() {
+        coupon = new TestCoupon("BBUSINSA_001", 100L);
+        testCouponRepository.save(coupon);
+    }
+
+    @Test
+    void 쿠폰차감_분산락_미적용_동시성100명_테스트() throws InterruptedException {
+        int numberOfThreads = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    couponService.reduceCouponStock(coupon.getId());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        TestCoupon persistCoupon = testCouponRepository.findById(coupon.getId())
+                .orElseThrow(() -> new BbusinsaException(ErrorType.COUPON_NOT_FOUND));
+
+        assertThat(persistCoupon.getAvailableStock()).isZero();
+        System.out.println("잔여 쿠폰 갯수 = " + persistCoupon.getAvailableStock());
+    }
+
+    @Test
+    void 쿠폰차감_동시성100명_테스트() throws InterruptedException {
+        int numberOfThreads = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    // 분산락 적용 메서드 호출 (락의 key는 쿠폰의 name으로 설정)
+                    couponService.reduceCouponStockWithLock(coupon.getId());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        TestCoupon persistCoupon = testCouponRepository.findById(coupon.getId())
+                .orElseThrow(() -> new BbusinsaException(ErrorType.COUPON_NOT_FOUND));
+
+        assertThat(persistCoupon.getAvailableStock()).isZero();
+        System.out.println("잔여 쿠폰 갯수 = " + persistCoupon.getAvailableStock());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+      url: jdbc:h2:mem:test
+      driverClassName: org.h2.Driver
+      username: sa
+      password:
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+    hibernate:
+      ddl-auto: create-drop
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      connect-timeout: 3000


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #14 

## 💡 작업 내용
- #9 의 하위 이슈로, 레디스 분산락을 이용해 쿠폰 발급 기능을 구현하였습니다.

## 배운 점
### 트랜잭션과 락의 우선순위가 중요함을 깨달았습니다.
- 만약 락이 트랜잭션보다 먼저 해제되면, 트랜잭션이 커밋되기 이전에 다른 쓰레드에서 락을 획득하고 커밋 이전의 트랜잭션을 얻게 되는 문제가 발생합니다.
- 따라서 `락 획득 -> 트랜잭션 begin -> 트랜잭션 commit/rollback -> 락 반납` 이렇게 진행되어야 합니다.

### 트랜잭션 전파
- 사실 기본값인 REQUIRED를 사용해도 현재 코드에서는 문제가 발생하지 않습니다.
- 다만, 부모 메서드(`reduceCouponStockWithLock`)에 트랜잭션이 존재하고, 자식 메서드(`reduceCouponStockWithTransaction`)에서 REQUIRES_NEW를 사용하면 부모 트랜잭션과 독립적인 트랜잭션이 생성됩니다.
- 또한 위 `트랜잭션과 락의 우선순위가 중요함을 깨달았습니다.` 이유때문이기도 합니다.

### 인터럽트
- 인터럽트는 쓰레드에게 작업을 멈춰달라고 요청하는 방식입니다.
- Redisson의 `tryLock(long waitTime, long leaseTime, TimeUnit unit)`에서 인터럽트가 발생할 수 있습니다.

## 📸 스크린샷(선택)
### 동시성 문제 발생한 경우 (100개의 쓰레드 - 100개 쿠폰)
![스크린샷 2025-02-27 오후 4 33 45](https://github.com/user-attachments/assets/2c1d836e-3d9f-48ce-a8b0-d2b4092fce0d)

### 동시성 문제를 락으로 해결한 경우 (100개의 쓰레드  - 100개 쿠폰)
![스크린샷 2025-02-27 오후 4 34 39](https://github.com/user-attachments/assets/70117dfd-7971-455a-8a3d-6ee78d58be36)

### 동시성 문제 발생한 경우 (500개의 쓰레드 - 10개 쿠폰)
![스크린샷 2025-02-27 오후 4 42 07](https://github.com/user-attachments/assets/73e905a2-b309-48cc-9a36-70151ac045b3)
ce-a8b0-d2b4092fce0d)

- 기대되는 동작
  - 총 500개의 요청 중 10개는 성공
  - 나머지 490개는 실패 (98% 실패율 기대)

- 실제 결과
  - 실패율이 84.8%
  - 즉, 75건(500 - 84.8% * 500)의 요청이 성공한 것

### 동시성 문제를 락으로 해결한 경우 (500개의 쓰레드 - 10개 쿠폰)
![스크린샷 2025-02-27 오후 4 45 18](https://github.com/user-attachments/assets/e7dcd18c-8054-4b37-a581-39d6c1f84857)
3d-6ee78d58be36)

- 기대되는 동작
  - 총 500개의 요청 중 10개는 성공
  - 나머지 490개는 실패 (98% 실패율 기대)

- 실제 결과
  - 기대되는 동작과 동일하게 수행됩니다.

## 🎸 기타
[참고 기술 블로그](https://helloworld.kurly.com/blog/distributed-redisson-lock/#2-redis%EC%9D%98-redisson-%EB%9D%BC%EC%9D%B4%EB%B8%8C%EB%9F%AC%EB%A6%AC-%EC%84%A0%EC%A0%95-%EC%9D%B4%EC%9C%A0)
- 다음 이슈는 Redisson이 아닌 Lettuce를 이용해서 락을 적용할 예정입니다.
- 부하테스트를 이번에 처음 해봐서, TPS나 다른 수치들도 공부를 할 예정입니다.