### PR TITLE
[Feat/#16] Redis spin lock을 이용하여 동시성 이슈를 해결한다

### DIFF
--- a/src/main/java/spring/bbusinsa/coupon/application/CouponService.java
+++ b/src/main/java/spring/bbusinsa/coupon/application/CouponService.java
@@ -4,5 +4,7 @@ public interface CouponService {
 
     void reduceCouponStock(Long couponId);
 
-    void reduceCouponStockWithLock(Long couponId);
+    void reduceCouponStockWithDistributedLock(Long couponId);
+
+    void reduceCouponStockWithSpinLock(Long couponId);
 }

--- a/src/main/java/spring/bbusinsa/coupon/application/CouponServiceImpl.java
+++ b/src/main/java/spring/bbusinsa/coupon/application/CouponServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import spring.bbusinsa.coupon.domain.entitty.TestCoupon;
@@ -22,6 +23,7 @@ public class CouponServiceImpl implements CouponService {
     private final CouponTransactionService couponTransactionService;
 
     private final RedissonClient redissonClient;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
     @Transactional
@@ -44,7 +46,7 @@ public class CouponServiceImpl implements CouponService {
     }
 
     @Override
-    public void reduceCouponStockWithLock(Long couponId) {
+    public void reduceCouponStockWithDistributedLock(Long couponId) {
         RLock lock = redissonClient.getLock("coupon:" + couponId);
         boolean isLocked = false;
 
@@ -70,5 +72,35 @@ public class CouponServiceImpl implements CouponService {
                 log.info("🔓 [쿠폰 차감] 쿠폰 ID: {} - 락 해제 완료", couponId);
             }
         }
+    }
+
+    @Override
+    public void reduceCouponStockWithSpinLock(Long couponId) {
+        try {
+            while (!lock(couponId)) {
+                log.warn("🚨 [쿠폰 차감] 쿠폰 ID: {} - 락 획득 실패: 다른 스레드가 이미 사용 중", couponId);
+                Thread.sleep(10);
+            }
+
+            log.info("✅ [쿠폰 차감] 쿠폰 ID: {} - 락 획득 성공! 처리 시작", couponId);
+            couponTransactionService.reduceCouponStockWithTransaction(couponId);
+            log.info("🎉 [쿠폰 차감] 쿠폰 ID: {} - 차감 완료!", couponId);
+
+        } catch (InterruptedException e) {
+            log.error("❌ [쿠폰 차감] 쿠폰 ID: {} - 락 획득 중 인터럽트 발생!", couponId, e);
+            throw new BbusinsaException(ErrorType.LOCK_ACQUISITION_FAILED);
+        } finally {
+            unlock(couponId);
+            log.info("🔓 [쿠폰 차감] 쿠폰 ID: {} - 락 해제 완료", couponId);
+        }
+    }
+
+    private Boolean lock(Long couponId) {
+        return redisTemplate.opsForValue()
+                .setIfAbsent("coupon:" + couponId, couponId, 5L, TimeUnit.SECONDS);
+    }
+
+    private void unlock(Long couponId) {
+        redisTemplate.delete("coupon:" + couponId);
     }
 }

--- a/src/main/java/spring/bbusinsa/coupon/presentation/CouponController.java
+++ b/src/main/java/spring/bbusinsa/coupon/presentation/CouponController.java
@@ -21,9 +21,15 @@ public class CouponController {
         return ApiResponse.success();
     }
 
-    @GetMapping("/claim/lock/{couponId}")
-    public ApiResponse<?> claimByLock(@PathVariable Long couponId) {
-        couponService.reduceCouponStockWithLock(couponId);
+    @GetMapping("/claim/distributed/{couponId}")
+    public ApiResponse<?> claimByRedissonLock(@PathVariable Long couponId) {
+        couponService.reduceCouponStockWithDistributedLock(couponId);
+        return ApiResponse.success();
+    }
+
+    @GetMapping("/claim/spin/{couponId}")
+    public ApiResponse<?> claimBySpinLock(@PathVariable Long couponId) {
+        couponService.reduceCouponStockWithSpinLock(couponId);
         return ApiResponse.success();
     }
 }

--- a/src/test/java/spring/bbusinsa/coupon/application/CouponServiceImplTest.java
+++ b/src/test/java/spring/bbusinsa/coupon/application/CouponServiceImplTest.java
@@ -58,7 +58,7 @@ class CouponServiceImplTest {
     }
 
     @Test
-    void 쿠폰차감_동시성100명_테스트() throws InterruptedException {
+    void 분산락_쿠폰차감_동시성100명_테스트() throws InterruptedException {
         int numberOfThreads = 100;
         ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
         CountDownLatch latch = new CountDownLatch(numberOfThreads);
@@ -66,8 +66,34 @@ class CouponServiceImplTest {
         for (int i = 0; i < numberOfThreads; i++) {
             executorService.submit(() -> {
                 try {
-                    // 분산락 적용 메서드 호출 (락의 key는 쿠폰의 name으로 설정)
-                    couponService.reduceCouponStockWithLock(coupon.getId());
+                    // 분산락 적용 메서드 호출 (락의 key는 쿠폰의 id로 설정)
+                    couponService.reduceCouponStockWithDistributedLock(coupon.getId());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        TestCoupon persistCoupon = testCouponRepository.findById(coupon.getId())
+                .orElseThrow(() -> new BbusinsaException(ErrorType.COUPON_NOT_FOUND));
+
+        assertThat(persistCoupon.getAvailableStock()).isZero();
+        System.out.println("잔여 쿠폰 갯수 = " + persistCoupon.getAvailableStock());
+    }
+
+    @Test
+    void 스핀락_쿠폰차감_동시성100명_테스트() throws InterruptedException {
+        int numberOfThreads = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    // 스핀락 적용 메서드 호출 (락의 key는 쿠폰의 id로 설정)
+                    couponService.reduceCouponStockWithSpinLock(coupon.getId());
                 } finally {
                     latch.countDown();
                 }


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #16 

## 💡 작업 내용
- #9 의 하위 이슈로, 레디스 spin lock을 이용해 쿠폰 발급 기능을 구현하였습니다.

## Spin Lock이란?
- 스레드가 락을 얻을 때까지 반복 루프를 돌며 확인하는 것을 말합니다.
- A 스레드가 실행되는 동안, 공유 자원에 락을 걸고 스레드 작업이 종료되면 락을 해제합니다.
- 이때 아직 점유하고 있지 않은 B 스레드(타 스레드)가 공유 자원의 상태를 반복 루프를 돌며 확인하는 방식을 spin lock이라 합니다.

### 특징
- Spin lock은 문맥 교환이 일어나지 않는 이점을 갖습니다.
- 그러나, 락을 획득할 때까지 무한 루프를 돌기 때문에 이 작업 자체가 CPU의 리소스를 많이 잡아 먹는 문제가 있습니다.

## 📸 스크린샷(선택)
### retry time : 0.01 초 (10ms)
![스크린샷 2025-03-01 오후 9 20 46](https://github.com/user-attachments/assets/58f2b4f4-a4ef-4901-9c3c-1e62f1ef15df)

### retry time : 0.1 초 (100ms)
![스크린샷 2025-03-01 오후 9 21 17](https://github.com/user-attachments/assets/d2688302-9b01-49f5-975d-d47f80e2aa9b)

`Exponential Backoff` 방식으로 retry 시간을 점진적으로 늘려가는 방법도 있다고 합니다.

## 🎸 기타
- Lock을 잘 알기 위해선, 운영체제를 잘 알아야 할 거 같네요..